### PR TITLE
Add support to configure reaction system

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,15 @@ twitch_miner = TwitchChannelPointsMiner(
                 where=Condition.LTE,            # 'by' must be [GT, LT, GTE, LTE] than value
                 value=800
             )
-        )
+        ),
+        react=True,                             # React to the streamer 
+    ),
+    reaction_settings=ReactionSettings(         # Customization of the reaction system, if used
+        reactions=[Reaction.WHAAAT,             # List of reactions to use
+            Reaction.FUNNY, 
+            Reaction.LOVE
+        ],  
+        interval_s=500,                         # Interval between reactions in seconds
     )
 )
 

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from TwitchChannelPointsMiner.classes.Chat import ChatPresence, ThreadChat
 from TwitchChannelPointsMiner.classes.entities.PubsubTopic import PubsubTopic
+from TwitchChannelPointsMiner.classes.entities.Reaction import ReactionSettings
 from TwitchChannelPointsMiner.classes.entities.Streamer import (
     Streamer,
     StreamerSettings,
@@ -21,7 +22,6 @@ from TwitchChannelPointsMiner.classes.Exceptions import StreamerDoesNotExistExce
 from TwitchChannelPointsMiner.classes.Settings import FollowersOrder, Priority, Settings
 from TwitchChannelPointsMiner.classes.Twitch import Twitch
 from TwitchChannelPointsMiner.classes.WebSocketsPool import WebSocketsPool
-from TwitchChannelPointsMiner.constants import Reaction
 from TwitchChannelPointsMiner.logger import LoggerSettings, configure_loggers
 from TwitchChannelPointsMiner.utils import (
     _millify,
@@ -64,8 +64,7 @@ class TwitchChannelPointsMiner:
         "minute_watcher_thread",
         "sync_campaigns_thread",
         "ws_pool",
-        "reactions",
-        "react_interval_s",
+        "reaction_settings",
         "session_id",
         "running",
         "start_datetime",
@@ -89,10 +88,7 @@ class TwitchChannelPointsMiner:
         logger_settings: LoggerSettings = LoggerSettings(),
         # Default values for all streamers
         streamer_settings: StreamerSettings = StreamerSettings(),
-        # Use reaction from this list
-        reactions: list = [Reaction.HYPE, Reaction.FUNNY, Reaction.LOVE, Reaction.WHAAAT, Reaction.OH_NO],
-        # minimal interval between reactions (5 min by default)
-        react_interval_s: int = 300,
+        reaction_settings: ReactionSettings = ReactionSettings(),
     ):
         # Fixes TypeError: 'NoneType' object is not subscriptable
         if not username or username == "your-twitch-username":
@@ -157,8 +153,7 @@ class TwitchChannelPointsMiner:
         self.sync_campaigns_thread = None
         self.reacting = None
         self.ws_pool = None
-        self.reactions = reactions
-        self.react_interval_s = react_interval_s
+        self.reaction_settings = reaction_settings
 
         self.session_id = str(uuid.uuid4())
         self.running = False
@@ -341,7 +336,7 @@ class TwitchChannelPointsMiner:
             ):
                 self.reacting = threading.Thread(
                     target=self.twitch.sync_react,
-                    args=(self.streamers, self.reactions, self.react_interval_s,),
+                    args=(self.streamers, self.reaction_settings,),
                 )
                 self.reacting.name = "Sync reacting"
                 self.reacting.start()

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -21,6 +21,7 @@ from TwitchChannelPointsMiner.classes.Exceptions import StreamerDoesNotExistExce
 from TwitchChannelPointsMiner.classes.Settings import FollowersOrder, Priority, Settings
 from TwitchChannelPointsMiner.classes.Twitch import Twitch
 from TwitchChannelPointsMiner.classes.WebSocketsPool import WebSocketsPool
+from TwitchChannelPointsMiner.constants import Reaction
 from TwitchChannelPointsMiner.logger import LoggerSettings, configure_loggers
 from TwitchChannelPointsMiner.utils import (
     _millify,
@@ -63,6 +64,8 @@ class TwitchChannelPointsMiner:
         "minute_watcher_thread",
         "sync_campaigns_thread",
         "ws_pool",
+        "reactions",
+        "react_interval_s",
         "session_id",
         "running",
         "start_datetime",
@@ -86,6 +89,10 @@ class TwitchChannelPointsMiner:
         logger_settings: LoggerSettings = LoggerSettings(),
         # Default values for all streamers
         streamer_settings: StreamerSettings = StreamerSettings(),
+        # Use reaction from this list
+        reactions: list = [Reaction.HYPE, Reaction.FUNNY, Reaction.LOVE, Reaction.WHAAAT, Reaction.OH_NO],
+        # minimal interval between reactions (5 min by default)
+        react_interval_s: int = 300,
     ):
         # Fixes TypeError: 'NoneType' object is not subscriptable
         if not username or username == "your-twitch-username":
@@ -150,6 +157,8 @@ class TwitchChannelPointsMiner:
         self.sync_campaigns_thread = None
         self.reacting = None
         self.ws_pool = None
+        self.reactions = reactions
+        self.react_interval_s = react_interval_s
 
         self.session_id = str(uuid.uuid4())
         self.running = False
@@ -332,7 +341,7 @@ class TwitchChannelPointsMiner:
             ):
                 self.reacting = threading.Thread(
                     target=self.twitch.sync_react,
-                    args=(self.streamers,),
+                    args=(self.streamers, self.reactions, self.react_interval_s,),
                 )
                 self.reacting.name = "Sync reacting"
                 self.reacting.start()

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -33,12 +33,12 @@ from TwitchChannelPointsMiner.classes.Settings import (
     Settings,
 )
 from TwitchChannelPointsMiner.classes.TwitchLogin import TwitchLogin
+from TwitchChannelPointsMiner.classes.entities.Reaction import Reaction, ReactionSettings
 from TwitchChannelPointsMiner.constants import (
     CLIENT_ID,
     CLIENT_VERSION,
     URL,
     GQLOperations,
-    Reaction,
 )
 from TwitchChannelPointsMiner.utils import (
     _millify,
@@ -813,11 +813,11 @@ class Twitch(object):
                             drop.is_claimed = self.claim_drop(drop)
                             time.sleep(random.uniform(5, 10))
 
-    def sync_react(self, streamers, reactions: list[Reaction], react_interval_s = 300, chunk_size=3):
+    def sync_react(self, streamers, reaction_settings: ReactionSettings, chunk_size=3):
         while self.running:
             for i in range(0, len(streamers)):
                 if streamers[i].is_react() is True:
-                    reaction = random.choice(reactions)
+                    reaction = reaction_settings.select_reaction()
                     res = self.react(streamer = streamers[i], reaction=reaction)
 
                     if res:
@@ -829,7 +829,7 @@ class Twitch(object):
                         # random delay before next reaction 
                         self.__chuncked_sleep(random.uniform(0.0, 2.0), chunk_size=chunk_size)
                     
-            self.__chuncked_sleep(react_interval_s, chunk_size=chunk_size)
+            self.__chuncked_sleep(reaction_settings.interval_s, chunk_size=chunk_size)
 
     def sync_campaigns(self, streamers, chunk_size=3):
         campaigns_update = 0

--- a/TwitchChannelPointsMiner/classes/entities/Reaction.py
+++ b/TwitchChannelPointsMiner/classes/entities/Reaction.py
@@ -1,0 +1,21 @@
+
+from enum import Enum
+import random
+
+
+class Reaction(Enum):
+    HYPE = "HYPE",
+    FUNNY = "FUNNY",
+    LOVE = "LOVE",
+    WHAAAT = "WHAAAT",
+    OH_NO = "OH_NO",
+
+class ReactionSettings:
+    def __init__(self, reactions: list[Reaction] = 
+                 [Reaction.HYPE, Reaction.FUNNY, Reaction.LOVE, Reaction.WHAAAT, Reaction.OH_NO],
+                 interval_s: int = 300):
+        self.reactions = reactions
+        self.interval_s = interval_s
+        
+    def select_reaction(self):
+        return random.choice(self.reactions)

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -36,7 +36,7 @@ class StreamerSettings(object):
         watch_streak: bool = None,
         bet: BetSettings = None,
         chat: ChatPresence = None,
-        react: bool = None,
+        react: bool = False,
     ):
         self.make_predictions = make_predictions
         self.follow_raid = follow_raid

--- a/TwitchChannelPointsMiner/constants.py
+++ b/TwitchChannelPointsMiner/constants.py
@@ -1,7 +1,4 @@
 # Twitch endpoints
-from enum import Enum
-
-
 URL = "https://www.twitch.tv"
 IRC = "irc.chat.twitch.tv"
 IRC_PORT = 6667
@@ -210,10 +207,3 @@ class GQLOperations:
             }
         },
     }
-
-class Reaction(Enum):
-    HYPE = "HYPE",
-    FUNNY = "FUNNY",
-    LOVE = "LOVE",
-    WHAAAT = "WHAAAT",
-    OH_NO = "OH_NO",

--- a/TwitchChannelPointsMiner/constants.py
+++ b/TwitchChannelPointsMiner/constants.py
@@ -1,4 +1,7 @@
 # Twitch endpoints
+from enum import Enum
+
+
 URL = "https://www.twitch.tv"
 IRC = "irc.chat.twitch.tv"
 IRC_PORT = 6667
@@ -207,3 +210,10 @@ class GQLOperations:
             }
         },
     }
+
+class Reaction(Enum):
+    HYPE = "HYPE",
+    FUNNY = "FUNNY",
+    LOVE = "LOVE",
+    WHAAAT = "WHAAAT",
+    OH_NO = "OH_NO",


### PR DESCRIPTION
# Description

- Add support to provide list of reactions
- Add support to select interval betwen reactions

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

1. Use client.py like this
```py
from TwitchChannelPointsMiner import TwitchChannelPointsMiner
from TwitchChannelPointsMiner.classes.entities.Reaction import ReactionSettings, Reaction
from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer, StreamerSettings


miner = TwitchChannelPointsMiner(
    username = 'my_user',
    password = 'my_pass',
    enable_analytics = True,
    streamer_settings = StreamerSettings(
        make_predictions = False,
        follow_raid = True,
        claim_drops = False,
        claim_moments = True,
        watch_streak = True,
        react=True   # <-- enable reactions
    ),
    # -- List of reactions to use --
    reaction_settings=ReactionSettings(reactions=[Reaction.WHAAAT, Reaction.FUNNY, Reaction.LOVE])
)

miner.mine(
    [
        Streamer('some_twitch_channel_name'),
    ],
    followers = False
)
```

Outout:
```
...
12/11/23 16:18:22 - INFO - [set_online]: Streamer(username=some_twitch_channel_name, channel_id=123456789, channel_points=1.13k) is Online!
12/11/23 16:18:24 - INFO - [sync_react]: some_twitch_channel_name - Reacted ('LOVE')
...
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
